### PR TITLE
Removing the default response 'ok' for message listeners

### DIFF
--- a/src/middleware/wer-middleware.raw.ts
+++ b/src/middleware/wer-middleware.raw.ts
@@ -62,7 +62,6 @@
         default:
           break;
       }
-      sendResponse('ok')
     });
 
     if (runtime.lastError) {
@@ -77,9 +76,7 @@
       if (action.type === SIGN_CONNECT) {
         console.log('on SIG_CONNECT')
         sendResponse(formatter("Connected to Web Extension Hot Reloader"));
-      } else {
-        sendResponse('ok');
-      }
+      } 
     });
 
     const socket = new WebSocket(wsHost)
@@ -163,7 +160,6 @@
         default:
           break;
       }
-      sendResponse('ok')
     });
   }
 


### PR DESCRIPTION
#### Checklist

- [ ] I ran the linting and formatting tools (ESLint and Prettier)
- [ ] I added addittional tests if adding new features

If messages are used in the extension code, they will not work, as according to Google's description, only the first response from handlers on the page will be sent if there are several of them. 

Docs: https://developer.chrome.com/docs/extensions/mv3/messaging/. 